### PR TITLE
Choice operators ending with "Path" should be Reference Paths

### DIFF
--- a/spec/States.html
+++ b/spec/States.html
@@ -1166,7 +1166,7 @@ $['store'][0]['book']</code></pre>
         <p>IsTimestamp</p>
       </li>
     </ol>
-    <p>For those operators that end with "Path", the value MUST be a
+    <p>For those operators that end with "Path", the value MUST be a Reference
       Path, to be applied to the state’s effective input to yield a value to
       be compared with the value yielded by the Variable path.</p>
     <p>For each operator which compares values, if the values are not both of the


### PR DESCRIPTION
In the same way TimeoutSecondsPath, HeartbeatSecondsPath,... are Reference Path, Choice operator ending with "Path" should also be limited to Reference Path instead of Path

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
