### PR TITLE
Fix example for array slicing

### DIFF
--- a/spec/States.html
+++ b/spec/States.html
@@ -368,7 +368,7 @@ $['store'][0]['book']</code></pre>
     "flagged": true,
     "parts": {
       "first.$": "$.vals[0]",
-      "last3.$": "$.vals[3:]"
+      "last3.$": "$.vals[-3:]"
     },
     "weekday.$": "$$.DayOfWeek",
     "formattedOutput.$": "States.Format('Today is {}', $$.DayOfWeek)"


### PR DESCRIPTION
This change fixes misleading example as the correct way to specify last 3 items is [-3:]

### Check

Use the following definition:

```
{
  "StartAt": "Hello",
  "States": {
    "Hello": {
      "Type": "Pass",
      "End": true,
      "Parameters": {
        "last3.$": "$.items[3:]"
      }
    }
  }
}
```

with input 
```
{
    "items": [1,2,3,4,5,6,7,8,9,10]
}
```

and the state output will be:

```
  { "last3": [4,5,6,7,8,9,10] }
```

Which is NOT the *last three* items.

Now change the definition to:

```
{
  "StartAt": "Hello",
  "States": {
    "Hello": {
      "Type": "Pass",
      "End": true,
      "Parameters": {
        "last3.$": "$.items[-3:]"
      }
    }
  }
}
```

with the same input and the output will be:

```
{ "last3": [8,9,10]}
```

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
