### PR TITLE
Fix typo under "terminal-state" section

### DIFF
--- a/spec/States.html
+++ b/spec/States.html
@@ -194,7 +194,7 @@
         <p id='terminal-state'>Any state except for Choice, Succeed, and
           Fail MAY have a field
           named "End" whose value MUST be a boolean. The term "Terminal
-          State" means a state with
+          State" means a state
           with <code class="nocheck">{ "End": true }</code>, or a state with
           <code class="nocheck">{ "Type": "Succeed" }</code>, or a state with
           <code class="nocheck">{ "Type": "Fail" }</code>.</p>


### PR DESCRIPTION
*Issue #, if available:*

N/A.

*Description of changes:*

Fix typo under "terminal-state" section, removing an extra "with".

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
